### PR TITLE
AU Base DiagnosticReport profile

### DIFF
--- a/ig.json
+++ b/ig.json
@@ -404,6 +404,10 @@
             "base": "StructureDefinition-au-diagnosticprocedurerequest.html",
             "defns": "StructureDefinition-au-diagnosticprocedurerequest-definitions.html"
         },
+        "StructureDefinition/au-diagnosticreport": {
+            "base": "StructureDefinition-au-diagnosticreport.html",
+            "defns": "StructureDefinition-au-diagnosticreport-definitions.html"
+        },
         "StructureDefinition/au-diagnosticobservation": {
             "base": "StructureDefinition-au-diagnosticobservation.html",
             "defns": "StructureDefinition-au-diagnosticobservation-definitions.html"

--- a/pages/_includes/au-diagnosticreport-intro.md
+++ b/pages/_includes/au-diagnosticreport-intro.md
@@ -1,0 +1,15 @@
+**AU Base Diagnostic Report** *[[FMM Level 0](guidance.html)]*
+
+This profile is intended to support all diagnostic reports including, pathology, diagnostic imaging and other diagnostic reports such as electrocardiograms, electroencephalograms, pulmonary function tests, colonoscopies, etc.
+
+Forthcoming work around this profile is expected to result in a value set representing the Standard for Pathology Informatics in Australia (SPIA) - Reporting codes bound as a slice on the code element.
+
+#### Identifiers
+These definitions represent common data held in the DiagnosticReport.identifier element:
+* Filler identifier [<sup>[1]</sup>](https://confluence.hl7australia.com/display/OOADRM20181/5+Observation+Ordering#id-5ObservationOrdering-5.4.1.3ORC-3Fillerordernumber(EI)00217) [<sup>[2]</sup>](http://ns.electronichealth.net.au/id/hpio-scoped/accessionnumber/1.0/index.html) [<sup>[3]</sup>](http://ns.electronichealth.net.au/id/hpio-scoped/report/1.0/index.html)
+
+#### Extensions
+Extensions used in this profile:
+* DiagnosticReport: performer-party [<sup>[1]</sup>](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-performer-party.html)
+* DiagnosticReport: category-additional [<sup>[1]</sup>](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-category-additional.html)
+<!-- * DiagnosticReport: resultsInterpreter [<sup>[1]</sup>](http://hl7.org/fhir/4.0/StructureDefinition/extension-DiagnosticReport.resultsInterpreter)  -->

--- a/pages/_includes/au-diagnosticreport-search.md
+++ b/pages/_includes/au-diagnosticreport-search.md
@@ -1,0 +1,2 @@
+none defined
+

--- a/pages/_includes/au-diagnosticreport-summary.md
+++ b/pages/_includes/au-diagnosticreport-summary.md
@@ -1,0 +1,3 @@
+This profile contains the following variations from [DiagnosticReport](http://hl7.org/fhir/STU3/DiagnosticReport):
+
+tbd

--- a/pages/_includes/au-diagnosticreport-watermark.md
+++ b/pages/_includes/au-diagnosticreport-watermark.md
@@ -1,0 +1,1 @@
+DRAFT<br/>ONLY

--- a/pages/_includes/profiles.md
+++ b/pages/_includes/profiles.md
@@ -33,6 +33,7 @@ These Profiles have been defined for this implementation guide.
 * [AU Base Specimen](StructureDefinition-au-specimen.html) - specimen details with local coding
 * [AU Assertion of No Relevant Finding](StructureDefinition-au-norelevantfinding.html) - observation with assertion of no relevant finding
 * [AU Base Diagnostic Procedure Request](StructureDefinition-au-diagnosticprocedurerequest.html) - diagnostic procedure request with localisation concepts
+* [AU Base Diagnostic Report](StructureDefinition-au-diagnosticreport.html) - diagnostic report with localisation concepts
 * [AU Base Diagnostic Observation](StructureDefinition-au-diagnosticobservation.html) - observation for diagnostic reporting
 
 

--- a/resources/au-diagnosticreport.xml
+++ b/resources/au-diagnosticreport.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="au-diagnosticreport" />
+  <url value="http://hl7.org.au/fhir/StructureDefinition/au-diagnosticreport" />
+  <version value="1.0.0" />
+  <name value="AUBaseDiagnosticReport" />
+  <title value="AU Base Diagnostic Report" />
+  <status value="draft" />
+  <date value="2019-06-24T10:07:00+11:00" />
+  <publisher value="Health Level Seven Australia (Orders and Observations WG)" />
+  <contact>
+    <telecom>
+      <system value="url" />
+      <value value="http://hl7.org.au/fhir" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This profile defines a diagnostic report structure that includes core localisation concepts for use in an Australian context." />
+  <fhirVersion value="3.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="DiagnosticReport" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="DiagnosticReport">
+      <path value="DiagnosticReport" />
+      <short value="A diagnostic report in an Australian healthcare context" />
+      <constraint>
+        <key value="inv-diagrep-0" />
+        <severity value="error" />
+        <human value="Additional category shall not be present if a category is absent" />
+        <expression value="DiagnosticReport.category.empty() implies DiagnosticReport.extension('http://hl7.org.au/fhir/StructureDefinition/category-additional').empty()" />
+      </constraint>
+    </element>
+    <element id="DiagnosticReport.extension:performerParty">
+      <path value="DiagnosticReport.extension" />
+      <sliceName value="performerParty" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/performer-party" />
+      </type>
+    </element>
+    <element id="DiagnosticReport.extension:categoryAdditional">
+      <path value="DiagnosticReport.extension" />
+      <sliceName value="categoryAdditional" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org.au/fhir/StructureDefinition/category-additional" />
+      </type>
+    </element>
+    <element id="DiagnosticReport.identifier">
+      <path value="DiagnosticReport.identifier" />
+      <slicing>
+        <discriminator>
+          <type value="pattern" />
+          <path value="type" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="DiagnosticReport.identifier:fillerIdentifier">
+      <path value="DiagnosticReport.identifier" />
+      <sliceName value="fillerIdentifier" />
+      <short value="Filler report identifier" />
+      <definition value="A Report Identifier is a unique identifier for each report. It must uniquely identify the report from all other reports in a particular source system (e.g. diagnostic Imaging system, clinical laboratory system). This uniqueness must persist over time. This Report Identifier is the same concept as the Filler Order Number in the HL7 V2 specifications. In some laboratory systems, the Report Identifier may be a concatenation of a Lab Number and Report panel code (e.g. 19P123456-FBC), where the panel code makes the identifier unique from other reports under the same Lab Number. In diagnostic imaging and some pathology systems, the report identifier may be called an accession number as long as there is only a single accession number per report." />
+    </element>
+    <element id="DiagnosticReport.identifier:fillerIdentifier.type">
+      <path value="DiagnosticReport.identifier.type" />
+      <min value="1" />
+      <binding>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
+          <valueString value="IdentifierType" />
+        </extension>
+        <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding">
+          <valueBoolean value="true" />
+        </extension>
+        <strength value="required" />
+        <valueSetReference>
+          <reference value="http://hl7.org.au/fhir/ValueSet/au-hl7v2-0203" />
+        </valueSetReference>
+      </binding>
+    </element>
+    <element id="DiagnosticReport.identifier:fillerIdentifier.type.coding">
+      <path value="DiagnosticReport.identifier.type.coding" />
+      <min value="1" />
+      <max value="1" />
+      <patternCodeableConcept>
+        <coding>
+          <system value="http://hl7.org/fhir/identifier-type" />
+          <code value="FILL" />
+        </coding>
+      </patternCodeableConcept>
+    </element>
+    <element id="DiagnosticReport.identifier:fillerIdentifier.system">
+      <path value="DiagnosticReport.identifier.system" />
+      <short value="Filler identifier system namespace" />
+      <min value="1" />
+    </element>
+    <element id="DiagnosticReport.identifier:fillerIdentifier.value">
+      <path value="DiagnosticReport.identifier.value" />
+      <short value="Filler identifier" />
+      <min value="1" />
+    </element>
+    <element id="DiagnosticReport.category">
+      <path value="DiagnosticReport.category" />
+      <binding>
+        <strength value="preferred" />
+        <valueSetUri value="http://hl7.org/fhir/ValueSet/diagnostic-service-sections" />
+      </binding>
+    </element>
+    <element id="DiagnosticReport.code">
+      <path value="DiagnosticReport.code"/>
+    </element>
+    <element id="DiagnosticReport.code.coding">
+      <path value="DiagnosticReport.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <discriminator>
+          <type value="value" />
+          <path value="code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="DiagnosticReport.code.coding:snomedImagingProcedures">
+      <path value="DiagnosticReport.code.coding" />
+      <sliceName value="snomedImagingProcedures" />
+      <short value="Diagnostic Imaging Procedures (SNOMED CT)"/>
+      <max value="1"/>
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/imaging-procedure-1" />
+      </binding>
+    </element>
+    <element id="DiagnosticReport.performer">
+      <path value="DiagnosticReport.performer" />
+      <max value="1" />
+    </element>
+    <element id="DiagnosticReport.performer.role">
+      <path value="DiagnosticReport.performer.role" />
+    </element>
+    <element id="DiagnosticReport.performer.role.coding">
+      <path value="DiagnosticReport.performer.role.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="DiagnosticReport.performer.role.coding:anzscoRole">
+      <path value="DiagnosticReport.performer.role.coding" />
+      <sliceName value="anzscoRole" />
+      <short value="Australian and New Zealand Standard Classification of Occupations" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/anzsco-1" />
+      </binding>
+    </element>
+    <element id="DiagnosticReport.performer.role.coding:snomedRole">
+      <path value="DiagnosticReport.performer.role.coding" />
+      <sliceName value="snomedRole" />
+      <short value="Practitioner Role (SNOMED CT)" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/practitioner-role-1" />
+      </binding>
+    </element>
+    <element id="DiagnosticReport.specimen">
+      <path value="DiagnosticReport.specimen" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-specimen" />
+      </type>
+    </element>
+    <element id="DiagnosticReport.codedDiagnosis">
+      <path value="DiagnosticReport.codedDiagnosis" />
+    </element>
+    <element id="DiagnosticReport.codedDiagnosis.coding">
+      <path value="DiagnosticReport.codedDiagnosis.coding"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="system"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="DiagnosticReport.codedDiagnosis.coding:snomedFinding">
+      <path value="DiagnosticReport.codedDiagnosis.coding"/>
+      <sliceName value="snomedFinding"/>
+      <short value="Clinical Finding (SNOMED CT)"/>
+      <max value="1"/>
+      <binding>
+        <strength value="required"/>
+        <description value="Clinical Finding (SNOMED CT)"/>
+        <valueSetUri value="https://healthterminologies.gov.au/fhir/ValueSet/clinical-finding-1"/>
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ig.xml
+++ b/resources/ig.xml
@@ -1310,6 +1310,13 @@
     </resource>
     <resource>
       <example value="false"/>
+      <name value="AU Base Diagnostic Report"/>
+      <sourceReference>
+        <reference value="StructureDefinition/au-diagnosticreport"/>
+      </sourceReference>
+    </resource>
+    <resource>
+      <example value="false"/>
       <name value="AU Base Diagnostic Observation"/>
       <sourceReference>
         <reference value="StructureDefinition/au-diagnosticobservation"/>


### PR DESCRIPTION
New AU Base DiagnosticReport profile - phase 1.  
Phase 2 will include terminology for pathology and pre-adoption of R4 content.
Note:  reference to "au-specimen" is not working as "au-specimen" is missing from the build when ported to STU3. 