### PR TITLE
Made the slices of Medication.ingredient.item[x] and MedicationStatement.medication[x] optional

### DIFF
--- a/resources/au-medication.xml
+++ b/resources/au-medication.xml
@@ -244,6 +244,7 @@
       <sliceName value="itemCodeableConcept" />
       <short value="Coded Ingredient Product" />
       <definition value="Coding for a substance or medicinal product  that is an ingredient of the medication." />
+	    <min value="0" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -269,6 +270,20 @@
           <reference value="http://hl7.org.au/fhir/ValueSet/amt-mp-codes" />
         </valueSetReference>
       </binding>
+    </element>    
+    <element id="Medication.ingredient.item[x]:itemReference">
+      <path value="Medication.ingredient.item[x]" />
+      <sliceName value="itemReference" />
+      <short value="Item Reference" />
+      <min value="0" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />
+      </type>
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-substance" />
+      </type>
     </element>
     <element id="Medication.ingredient.amount">
       <path value="Medication.ingredient.amount" />

--- a/resources/au-medicationstatement.xml
+++ b/resources/au-medicationstatement.xml
@@ -81,6 +81,7 @@
       <path value="MedicationStatement.medication[x]" />
       <sliceName value="medicationCodeableConcept" />
       <short value="Coded Medication" />
+	  <min value="0" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -221,6 +222,7 @@
       <path value="MedicationStatement.medication[x]" />
       <sliceName value="medicationReference" />
       <short value="Medication Reference" />
+	  <min value="0" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://hl7.org.au/fhir/StructureDefinition/au-medication" />


### PR DESCRIPTION
Hi Brett,

This is pull request where the following has been done.

1) For MedicationStatement.medication[x] relaxed the cardinality of medicationCodableConcept and medicationReference from 1..1 to 0..1

2) For Medication.ingredient.item[x] relaxed the cardinality of itemCodableConcept from 1..1 to 0..1. For itemReference a new slice has been created with cardinality of 0..1 and the references allowed has been updated to au-medication and au-substance profiles instead of STU3 medication and substance resources.

I have tested the profile update with all major variations of example files and all of the negative and positive tests passed. The changes were also peer reviewed. 

Request to please review and do the needful. Please let me know if more work is needed in this. 

Thanks. 
Vikas 